### PR TITLE
add option to launch Qt version

### DIFF
--- a/Source/Release/setup.iss
+++ b/Source/Release/setup.iss
@@ -16,6 +16,7 @@ OutputBaseFilename=setup
 SetupIconFile=..\res\bunn.ico
 Compression=lzma
 SolidCompression=yes
+PrivilegesRequired=lowest
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/Source/controllers/data_control.py
+++ b/Source/controllers/data_control.py
@@ -33,6 +33,16 @@ class UserDataControl:
         except:
             self.set_auto_launch(False)
             return False
+    
+    def set_qt(self, launch_qt):
+        self._sh['launch_qt'] = launch_qt
+
+    def get_qt(self):
+        try:
+            return self._sh.get('launch_qt', False)
+        except:
+            self.set_qt(False)
+            return False
 
     def set_hide_changelog(self, hide_status):
         self._sh['hide_changelog'] = hide_status

--- a/Source/dolphinapp.py
+++ b/Source/dolphinapp.py
@@ -169,8 +169,6 @@ class DolphinUpdate(QMainWindow):
         self.auto_launch_check = QCheckBox(settings_frame)
         self.auto_launch_check.setChecked(self._udc.get_auto_launch())
         settings_form.addRow("Auto Launch?", self.auto_launch_check)
-        settings_form.setContentsMargins(0, 1, 2, 0)
-        self.statusBar().addPermanentWidget(settings_frame)
         
         self.launch_qt_check = QCheckBox(settings_frame)
         self.launch_qt_check.setChecked(self._udc.get_qt())

--- a/Source/dolphinapp.py
+++ b/Source/dolphinapp.py
@@ -164,23 +164,33 @@ class DolphinUpdate(QMainWindow):
         toolbar.addSeparator()
         toolbar.addAction(launch_dolphin_action)
 
-        auto_launch_frame = QFrame()
-        auto_launch_form = QFormLayout(auto_launch_frame)
-        self.auto_launch_check = QCheckBox(auto_launch_frame)
+        settings_frame = QFrame()
+        settings_form = QFormLayout(settings_frame)
+        self.auto_launch_check = QCheckBox(settings_frame)
         self.auto_launch_check.setChecked(self._udc.get_auto_launch())
-        auto_launch_form.addRow("Auto Launch?", self.auto_launch_check)
-        auto_launch_form.setContentsMargins(0, 1, 2, 0)
-        self.statusBar().addPermanentWidget(auto_launch_frame)
-
+        settings_form.addRow("Auto Launch?", self.auto_launch_check)
+        settings_form.setContentsMargins(0, 1, 2, 0)
+        self.statusBar().addPermanentWidget(settings_frame)
+        
+        self.launch_qt_check = QCheckBox(settings_frame)
+        self.launch_qt_check.setChecked(self._udc.get_qt())
+        settings_form.addRow("Launch QT Version?", self.launch_qt_check)
+        settings_form.setContentsMargins(0, 1, 2, 0)
+        self.statusBar().addPermanentWidget(settings_frame)
+    
     def launch_dolphin(self):
         dolphin_dir = self.dolphin_dir.text()
         if not dolphin_dir:
             self.show_warning('Please select a dolphin folder.')
             return
 
-        dolphin_path = os.path.join(dolphin_dir, 'Dolphin.exe')
+        if (self.launch_qt_check.isChecked() == False):
+          dolphinexe = 'Dolphin.exe'
+        else:
+          dolphinexe = 'DolphinQt2.exe'
+        dolphin_path = os.path.join(dolphin_dir, dolphinexe)
         if not os.path.isfile(dolphin_path):
-            self.show_warning('Could not find "Dolphin.exe".')
+            self.show_warning('Could not find "' + dolphinexe + '".')
             return
 
         subprocess.Popen(dolphin_path, cwd=dolphin_dir)
@@ -278,6 +288,7 @@ class DolphinUpdate(QMainWindow):
     # PyQt closeEvent called on exit
     def closeEvent(self, event):
         self._udc.set_auto_launch(self.auto_launch_check.isChecked())
+        self._udc.set_qt(self.launch_qt_check.isChecked())
         if self.download_thread.isRunning():
             event.ignore()
             reply = QMessageBox.question(self, 'Exit', "Are you sure you want to quit?", QMessageBox.Yes |


### PR DESCRIPTION
Since the Dolphin Qt2 version is catching up to the wxWidgets version, I thought to try and add this.

This also possibly removes admin privileges required in setup, it seems like correct syntax according to highlights in a version I was using; I wasn't able to test it though.

Other than that, I tested launching and setting the setting and it worked. Take that as you will.